### PR TITLE
RTU Timer & ASCII 7N2 Verification

### DIFF
--- a/Core/_ILX34-MBS/MBPort.c
+++ b/Core/_ILX34-MBS/MBPort.c
@@ -1138,9 +1138,10 @@ void StopTimeout(void)
 
 /********************* RTU TIMEOUT SYSTEM ************************/
 BYTE TimerL,TimerH;
-const unsigned int RTU_Timeout[6] = { 29166, 14583, 7292, 3646, 1823, 912 };
+//const unsigned int RTU_Timeout[6] = { 29166, 14583, 7292, 3646, 1823, 912 };
 // 1200>0.029166667, 2400>0.014583333, 4800>0.007291667, 9600>0.003645833, 19200>0.001822917, 38400>0.000911458
-
+//unsigned int BaudDiv[8] = { BAUD19, BAUD12, BAUD24, BAUD48, BAUD96, BAUD38 };
+const unsigned int RTU_Timeout[6] = { 1823, 29166, 14583, 7292, 3646, 912 };
 
 /**
  * @brief InitRtuTimeout() Initialized RTU timer with buad rate based timeout.
@@ -2762,7 +2763,7 @@ void main_port_serial (void)
          if ( ModbusConfig.type == MB_SLAVEMODE ) {
             MB_Status = READY_FOR_COMMAND;
          }
-         TriggerCOS();
+//         TriggerCOS(); //TODO Jignesh to avoid zerto PLC
       }
    }
 


### PR DESCRIPTION

- Apply the changes for RTU timeout value according to new Baudrate setting.

//unsigned int BaudDiv[8] = { BAUD19, BAUD12, BAUD24, BAUD48, BAUD96, BAUD38 };
const unsigned int RTU_Timeout[6] = { 1823, 29166, 14583, 7292, 3646, 912 };

- MODBUS ASCII 7N2 verification for given examples using below setting in code. 

	case FRAME_7N2:
		// special case for our driver
		// We will need to mask off one stop bit out of the 8 data bits
		DSC_Writes (DSC_LEVEL_INFO, "7N2\r\n");
		sh_flag_7N2	   = 1;
		sh_word_length = UART_WORDLENGTH_8B; 
		sh_stop_bits   = UART_STOPBITS_1; 
		sh_parity	   = UART_PARITY_NONE;

